### PR TITLE
Change PROJECTNAME_ links to `PROJECTNAME`_ to accommodate project names with spaces

### DIFF
--- a/gitwash/development_workflow.rst
+++ b/gitwash/development_workflow.rst
@@ -4,7 +4,7 @@
 Development workflow
 ####################
 
-You already have your own forked copy of the PROJECTNAME_ repository, by
+You already have your own forked copy of the `PROJECTNAME`_ repository, by
 following :ref:`forking`. You have :ref:`set-up-fork`. You have configured
 git by following :ref:`configure-git`.  Now you are ready for some real work.
 
@@ -81,7 +81,7 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     git checkout my-new-feature
 
 Generally, you will want to keep your feature branches on your public github_
-fork of PROJECTNAME_.  To do this, you `git push`_ this new branch up to your
+fork of `PROJECTNAME`_.  To do this, you `git push`_ this new branch up to your
 github repo.  Generally (if you followed the instructions in these pages, and by
 default), git will have a link to your github repo, called ``origin``.  You push
 up to your own repo on github with::

--- a/gitwash/forking_hell.rst
+++ b/gitwash/forking_hell.rst
@@ -1,13 +1,13 @@
 .. _forking:
 
-==========================================
+======================================================
 Making your own copy (fork) of PROJECTNAME
-==========================================
+======================================================
 
 You need to do this only once.  The instructions here are very similar
 to the instructions at http://help.github.com/forking/ |emdash| please see
 that page for more detail.  We're repeating some of it here just to give the
-specifics for the PROJECTNAME_ project, and to suggest some default names.
+specifics for the `PROJECTNAME`_ project, and to suggest some default names.
 
 Set up and configure a github account
 =====================================
@@ -17,17 +17,17 @@ If you don't have a github account, go to the github page, and make one.
 You then need to configure your account to allow write access |emdash| see
 the ``Generating SSH keys`` help on `github help`_.
 
-Create your own forked copy of PROJECTNAME_
-===========================================
+Create your own forked copy of `PROJECTNAME`_
+======================================================
 
 #. Log into your github account.
-#. Go to the PROJECTNAME_ github home at `PROJECTNAME github`_.
+#. Go to the `PROJECTNAME`_ github home at `PROJECTNAME github`_.
 #. Click on the *fork* button:
 
    .. image:: forking_button.png
 
    Now, after a short pause and some 'Hardcore forking action', you
-   should find yourself at the home page for your own forked copy of PROJECTNAME_.
+   should find yourself at the home page for your own forked copy of `PROJECTNAME`_.
 
 .. include:: links.inc
 

--- a/gitwash/git_intro.rst
+++ b/gitwash/git_intro.rst
@@ -2,7 +2,7 @@
  Introduction
 ==============
 
-These pages describe a git_ and github_ workflow for the PROJECTNAME_
+These pages describe a git_ and github_ workflow for the `PROJECTNAME`_
 project.
 
 There are several different workflows here, for different ways of

--- a/gitwash/index.rst
+++ b/gitwash/index.rst
@@ -1,7 +1,7 @@
 .. _using-git:
 
 Working with *PROJECTNAME* source code
-======================================
+================================================
 
 Contents:
 

--- a/gitwash/patching.rst
+++ b/gitwash/patching.rst
@@ -3,7 +3,7 @@
 ================
 
 You've discovered a bug or something else you want to change
-in PROJECTNAME_ .. |emdash| excellent!
+in `PROJECTNAME`_ .. |emdash| excellent!
 
 You've worked out a way to fix it |emdash| even better!
 
@@ -57,7 +57,7 @@ In detail
       git config --global user.name "Your Name Comes Here"
 
 #. If you don't already have one, clone a copy of the
-   PROJECTNAME_ repository::
+   `PROJECTNAME`_ repository::
 
       git clone git://github.com/MAIN_GH_USER/REPONAME.git
       cd REPONAME
@@ -115,7 +115,7 @@ more feature branches, you will probably want to switch to
 development mode.  You can do this with the repository you
 have.
 
-Fork the PROJECTNAME_ repository on github |emdash| :ref:`forking`.
+Fork the `PROJECTNAME`_ repository on github |emdash| :ref:`forking`.
 Then::
 
    # checkout and refresh master branch from main repo

--- a/gitwash/set_up_fork.rst
+++ b/gitwash/set_up_fork.rst
@@ -49,7 +49,7 @@ Linking your repository to the upstream repo
    git remote add upstream git://github.com/MAIN_GH_USER/REPONAME.git
 
 ``upstream`` here is just the arbitrary name we're using to refer to the
-main PROJECTNAME_ repository at `PROJECTNAME github`_.
+main `PROJECTNAME`_ repository at `PROJECTNAME github`_.
 
 Note that we've used ``git://`` for the URL rather than ``git@``.  The
 ``git://`` URL is read only.  This means we that we can't accidentally

--- a/gitwash_dumper.py
+++ b/gitwash_dumper.py
@@ -120,7 +120,7 @@ def make_link_targets(proj_name,
     have_gh_url = None
     for line in link_contents:
         if not have_url:
-            match = re.match(r'..\s+_%s:\s+' % proj_name, line)
+            match = re.match(r'..\s+_`%s`:\s+' % proj_name, line)
             if match:
                 have_url = True
         if not have_ml_url:
@@ -136,7 +136,7 @@ def make_link_targets(proj_name,
                            'and / or mailing list URLs')
     lines = []
     if not url is None:
-        lines.append('.. _%s: %s\n' % (proj_name, url))
+        lines.append('.. _`%s`: %s\n' % (proj_name, url))
     if not have_gh_url:
         gh_url = 'http://github.com/%s/%s\n' % (user_name, repo_name)
         lines.append('.. _`%s github`: %s\n' % (proj_name, gh_url))


### PR DESCRIPTION
Also, I fixed a few header underlinings to accommodate longer titles.

We ran into this when trying to use gitwash with the "Sage Notebook" project.  Now this works:

```
python gitwash_dumper.py --gitwash-url git://github.com/jasongrout/gitwash.git --gitwash-branch projectname-quotes --repo-name=sagenb --github-user=sagemath --project-url=http://sagemath.org --project-ml-url=http://groups.google.com/group/sage-notebook doc/ "Sage Notebook"
```
