### PR TITLE
recent debian and ubuntu have obsoleted git-core package name

### DIFF
--- a/gitwash/git_install.rst
+++ b/gitwash/git_install.rst
@@ -8,7 +8,7 @@ Overview
 ========
 
 ================ =============
-Debian / Ubuntu  ``sudo apt-get install git-core``
+Debian / Ubuntu  ``sudo apt-get install git``
 Fedora           ``sudo yum install git-core``
 Windows          Download and install msysGit_
 OS X             Use the git-osx-installer_


### PR DESCRIPTION
The `git-core` package name has been obsoleted by `git` since at least Debian Squeeze and Ubuntu 12.04.
