### PR TITLE
Python 3 compatibility

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import (absolute_import, division, print_function)
+
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/gitwash_dumper.py
+++ b/gitwash_dumper.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 ''' Checkout gitwash repo into directory and do search replace on name '''
 
+from __future__ import print_function
+
 import os
 from os.path import join as pjoin
 import shutil
@@ -79,7 +81,7 @@ def copy_replace(replace_pairs,
     for rep_glob in rep_globs:
         fnames += fnmatch.filter(out_fnames, rep_glob)
     if verbose:
-        print '\n'.join(fnames)
+        print('\n'.join(fnames))
     for fname in fnames:
         filename_search_replace(replace_pairs, fname, False)
         for in_exp, out_exp in renames:

--- a/gitwash_dumper.py
+++ b/gitwash_dumper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 ''' Checkout gitwash repo into directory and do search replace on name '''
 
-from __future__ import print_function
+from __future__ import (absolute_import, division, print_function)
 
 import os
 from os.path import join as pjoin

--- a/gitwash_dumper.py
+++ b/gitwash_dumper.py
@@ -56,16 +56,19 @@ def filename_search_replace(sr_pairs, filename, backup=False):
     ''' Search and replace for expressions in files
 
     '''
-    in_txt = open(filename, 'rt').read(-1)
+    with open(filename, 'rt') as in_fh:
+        in_txt = in_fh.read(-1)
     out_txt = in_txt[:]
     for in_exp, out_exp in sr_pairs:
         in_exp = re.compile(in_exp)
         out_txt = in_exp.sub(out_exp, out_txt)
     if in_txt == out_txt:
         return False
-    open(filename, 'wt').write(out_txt)
+    with open(filename, 'wt') as out_fh:
+        out_fh.write(out_txt)
     if backup:
-        open(filename + '.bak', 'wt').write(in_txt)
+        with open(filename + '.bak', 'wt') as bak_fh:
+            bak_fh.write(in_txt)
     return True
 
 
@@ -116,7 +119,8 @@ def make_link_targets(proj_name,
     .. _`proj_name`: url
     .. _`proj_name` mailing list: url
     """
-    link_contents = open(known_link_fname, 'rt').readlines()
+    with open(known_link_fname, 'rt') as link_fh:
+        link_contents = link_fh.readlines()
     have_url = not url is None
     have_ml_url = not ml_url is None
     have_gh_url = None
@@ -149,9 +153,8 @@ def make_link_targets(proj_name,
         return
     # A neat little header line
     lines = ['.. %s\n' % proj_name] + lines
-    out_links = open(out_link_fname, 'wt')
-    out_links.writelines(lines)
-    out_links.close()
+    with open(out_link_fname, 'wt') as out_links:
+        out_links.writelines(lines)
 
 
 USAGE = ''' <output_directory> <project_name>

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,6 +1,8 @@
 """ Testing gitwash dumper
 """
 
+from __future__ import (absolute_import, division, print_function)
+
 import os
 from os.path import join as pjoin, dirname, split as psplit
 import sys

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -52,7 +52,9 @@ def test_link_checks():
         test_fname,
         'http://nowhere.org',
         None)
-    assert_equal(open(test_fname, 'rt').read(),
+    with open(test_fname, 'rt') as test_fh:
+        expected_text = test_fname.read()
+    assert_equal(expected_text,
                  """.. nipy
 .. _nipy: http://nowhere.org
 """)
@@ -89,7 +91,8 @@ def test_building():
     shutil.copy(pjoin(ROOT_DIR, 'conf.py'), TMPDIR)
     try:
         os.chdir(TMPDIR)
-        open('index.rst', 'wt').write('\n')
+        with open('index.rst', 'wt') as index_fh:
+            index_fh.write('\n')
         call('sphinx-build -b html -d _build/doctrees   . _build/html',
              shell=True)
         call('sphinx-build -b linkcheck -d _build/doctrees   . _build/linkcheck',


### PR DESCRIPTION
A collection of changes made in [https://github.com/SciTools/iris](iris) to ensure Python 3 compatibility. You may wish to ignore the addition of the `six` compatibility routines since almost none of those builtins are used, but you might want to leave it in anyway just in case that changes in the future.