### PR TITLE
Fix a typo and update the related URL in GitHub doc.

### DIFF
--- a/gitwash/development_workflow.rst
+++ b/gitwash/development_workflow.rst
@@ -182,8 +182,8 @@ Delete a branch on github
    # delete branch on github
    git push origin :my-unwanted-branch
 
-(Note the colon ``:`` before ``test-branch``.  See also:
-http://github.com/guides/remove-a-remote-branch
+Note the colon ``:`` before ``my-unwanted-branch``.  See also:
+https://help.github.com/articles/pushing-to-a-remote/#deleting-a-remote-branch-or-tag
 
 Several people sharing a single repository
 ------------------------------------------


### PR DESCRIPTION
Here is a small fix similar to [matplotlib PR #7136](https://github.com/matplotlib/matplotlib/pull/7136) :
* `test-branch` does not appear in the block of code above l. 185 ;
* the former provided URL redirects towards [https://help.github.com/categories/managing-remotes/](https://help.github.com/categories/managing-remotes/), so this PR updates it to the new relevant location.