### PR TITLE
Fedora swtiched from yum to dnf a few years ago

### DIFF
--- a/gitwash/git_install.rst
+++ b/gitwash/git_install.rst
@@ -11,7 +11,7 @@ Overview
 
 ================ =============
 Debian / Ubuntu  ``sudo apt-get install git``
-Fedora           ``sudo yum install git``
+Fedora           ``sudo dnf install git``
 Windows          Download and install msysGit_
 OS X             Use the git-osx-installer_
 ================ =============


### PR DESCRIPTION
Ready to merge.

DNF became the default in 2014 with Fedora release 22:
https://fedoraproject.org/wiki/Releases/22/ChangeSet#Replace_Yum_With_DNF