### PR TITLE
Don't capitalize git even at sentence start.

### DIFF
--- a/gitwash/development_workflow.rst
+++ b/gitwash/development_workflow.rst
@@ -402,7 +402,7 @@ This means that (i) we want to edit the commit message for
 ``13d7934``, and (ii) collapse the last three commits into one. Now we
 save and quit the editor.
 
-Git will then immediately bring up an editor for editing the commit
+git will then immediately bring up an editor for editing the commit
 message. After revising it, we get the output::
 
     [detached HEAD 721fc64] FOO: First implementation

--- a/gitwash/git_development.rst
+++ b/gitwash/git_development.rst
@@ -1,7 +1,7 @@
 .. _git-development:
 
 =====================
- Git for development
+ git for development
 =====================
 
 Contents:


### PR DESCRIPTION
This is consistent with the section "git resources" which is likewise
not capitalized.