### PR TITLE
git to https round 2

### DIFF
--- a/gitwash_dumper.py
+++ b/gitwash_dumper.py
@@ -166,7 +166,7 @@ If not set with options, the main github user is the same as the
 repository name.'''
 
 
-GITWASH_CENTRAL = 'git://github.com/matthew-brett/gitwash.git'
+GITWASH_CENTRAL = 'https://github.com/matthew-brett/gitwash.git'
 GITWASH_BRANCH = 'main'
 
 


### PR DESCRIPTION
Follow-up to #20 which missed this one.  Gitwash times out and the error log is rather unhelpful when falling back to the default option for projects who didn't specify the `--gitwash-url` parameter.